### PR TITLE
Added 'location' to the data returned from processRemoteData.

### DIFF
--- a/lib/uwmadison_events.class.php
+++ b/lib/uwmadison_events.class.php
@@ -248,6 +248,7 @@ class UwmadisonEvents {
         'all_day_event' => $event->allDayEvent,
         'link' => $this->eventLink($event),
         'narrative_listing' => $event->narrative_listing,
+        'location' => $event->location,
       );
 
       // Append to grouped and ungrouped output


### PR DESCRIPTION
Event location data was omitted from the data returned when querying for events.  This patch corrects that.
