### PR TITLE
Handle no events in calendar

### DIFF
--- a/lib/uwmadison_events.class.php
+++ b/lib/uwmadison_events.class.php
@@ -172,7 +172,10 @@ class UwmadisonEvents {
       }
       else {
         $get = wp_remote_get($built_url);
-        if ( isset($get['response']['code']) && !preg_match('/^(4|5)/', $get['response']['code']) ) {
+		if( is_wp_error( $get ) ) {
+			return FALSE;
+		}
+		elseif ( isset($get['response']['code']) && !preg_match('/^(4|5)/', $get['response']['code']) ) {
           $remote_data = json_decode($get['body']);
           set_transient($cache_key, $remote_data, $this->cache_expiration);
         }

--- a/lib/uwmadison_events.class.php
+++ b/lib/uwmadison_events.class.php
@@ -332,7 +332,10 @@ class UwmadisonEvents {
       $cache_key = 'uwe_event_' . $id;
       if ( ( $data = get_transient($cache_key) ) === FALSE ) {
         $get = wp_remote_get($this->api_base . '/events/view/' . $id . '.json');
-        if ( isset($get['response']['code']) && !preg_match('/^(4|5)/', $get['response']['code']) ) {
+		if( is_wp_error( $get ) ) {
+			return FALSE;
+		}
+		elseif ( isset($get['response']['code']) && !preg_match('/^(4|5)/', $get['response']['code']) ) {
           $data = json_decode($get['body']);
           set_transient($cache_key, $data, $this->cache_expiration);
         }


### PR DESCRIPTION
When a calendar has no events a WP_Error object is returned. Change
checks for that and returns false if found.