### PR TITLE
Replace deprecated function with anonymous function

### DIFF
--- a/lib/uwmadison_events.class.php
+++ b/lib/uwmadison_events.class.php
@@ -31,7 +31,7 @@ if ( !class_exists("UwmadisonEvents") ) {
      */
     public function init() {
       // Register the widget class
-      add_action( 'widgets_init', create_function( '', 'register_widget( "UwmadisonEventsWidget" );' ) );
+      add_action( 'widgets_init', function() { register_widget( "UwmadisonEventsWidget" ); } );
       // A short code wrapper for ::parse()
       add_shortcode( 'uwmadison_events', array( &$this, 'shortCode') );
     }


### PR DESCRIPTION
@jnweaver 
Replace the deprecation function `create_function()` with an anonymous function. The [create function](http://php.net/manual/en/function.create-function.php) is now deprecated in PHP version 7.2. 